### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,10 @@
 # Reporting a Vulnerability
 
 mail to: kiranxrx8@gmail.com
+
+
+# Reporting a Vulnerability
+
+If you discover a security vulnerability in covid-19-vaccine-registration please disclose it via [our huntr page](https://huntr.dev/repos/7h3h4ckv157/covid-19-vaccine-registration/). Bounty eligibility, CVE assignment, response times and past reports are all there.
+
+Thank you for improving the security of covid-19-vaccine-registration.


### PR DESCRIPTION
As requested through the platform by @7h3h4ckv157, this will point your security policy to [huntr.dev](https://huntr.dev/repos/7h3h4ckv157/covid-19-vaccine-registration})